### PR TITLE
Wrong product code for MH4U, conflicts with shaphire

### DIFF
--- a/source/secure_values.c
+++ b/source/secure_values.c
@@ -22,7 +22,7 @@ const char const secureProductCodes[PRECONF_GAMES][16] = {"CTR-P-EGD",
     "CTR-P-EKJ", "CTR-P-EK2",
     "CTR-P-ECR", "CTR-P-ECL"}; // minus region
 const char* const pokeRumbleWorldCode = "CTR-N-KCF";
-const char* const MH4UCode = "XXXXXXXXX";
+const char* const MH4UCode = "CTR-P-BFG";
 
 char configProductCode[9] = {0};
 

--- a/source/secure_values.c
+++ b/source/secure_values.c
@@ -22,7 +22,7 @@ const char const secureProductCodes[PRECONF_GAMES][16] = {"CTR-P-EGD",
     "CTR-P-EKJ", "CTR-P-EK2",
     "CTR-P-ECR", "CTR-P-ECL"}; // minus region
 const char* const pokeRumbleWorldCode = "CTR-N-KCF";
-const char* const MH4UCode = "CTR-P-ECL";
+const char* const MH4UCode = "XXXXXXXXX";
 
 char configProductCode[9] = {0};
 


### PR DESCRIPTION
My bad, turns out my now dissapeared tester sent me the wrong product code for monster hunter 4 ultimate and I didn't notice it is that of pokemon alpha shapphire, so 10.42 breaks alpha shapphire.

Also, is the middle letter from product code the region letter? Does this only work with EUR games?
