### PR TITLE
Emergency mode title fetching and disable MH4U

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -522,14 +522,14 @@ void printAlert()
 }
 
 char titleTitle[0x40];
-int titleTitle_set = 0;
+int titleTitle_set = -1;
 
 void printTarget()
 {
     consoleSelect(&notifyBar);
     consoleClear();
     gotoxy(0,0);
-    if(titleTitle_set)
+    if(titleTitle_set > -1)
     {
         textcolour(TEAL);
         printf("Title: ");
@@ -600,7 +600,7 @@ int main()
         fclose (pFile);
 */
 	    getTitleList(mediatype,&titleTitles_available);
-		if (!titleTitle_set){
+		if (titleTitle_set < 0){
 			if (tid2 != 0){
 				lsTitle* currentTitle = firstTitle;
 				int i = 0;
@@ -642,7 +642,7 @@ int main()
         machine_state = SELECT_SAVE;
         memset(destPath,0,MAX_PATH_LENGTH);
         gotoSubDirectory(&cwd_sdmc,"svdt");
-        if (titleTitle_set)
+        if (titleTitle_set > -1)
         {
             strcat(destPath,"/svdt/");
             strcat(destPath,titleTitle);
@@ -651,7 +651,7 @@ int main()
         }
         copyDir(&cwd_save,NULL,&cwd_sdmc,tempStr);
         gotoParentDirectory(&cwd_sdmc);
-        if (titleTitle_set)
+        if (titleTitle_set > -1)
         {
             gotoParentDirectory(&cwd_sdmc);
         }
@@ -778,7 +778,7 @@ int main()
         gotoxy(0,10);
         int i;
         for (i=0;i<BOTTOM_WIDTH;i++) { printf(" "); }
-		if (!titleTitle_set){
+		if (titleTitle_set < 0){
 			if (tid2 != 0){
 				lsTitle* currentTitle = firstTitle;
 				int i = 0;
@@ -794,7 +794,7 @@ int main()
 				}
 			}
 		}
-        if (!titleTitle_set)
+        if (titleTitle_set < 0)
             nthTitleInList(titleTitle_set,mediatype,titleTitle,&tid);
         AM_GetTitleProductCode(mediatype,tid,productCodeBuffer);
         strncpy(productCode,productCodeBuffer,9);
@@ -859,13 +859,13 @@ int main()
                 printf(productCode);
                 printf(" - %016llX", tid);
             }
-            if(hidKeysDown() & KEY_A)
+            if(hidKeysDown() & KEY_A || titleTitle_set > -1)
             {
                 printInstructions();
                 printTarget();
                 previous_state = machine_state;
                 machine_state = SELECT_SDMC;
-                if (canHasConsole == 2 && !titleTitle_set)
+                if (canHasConsole == 2 && titleTitle_set < 0)
                 {
                     debugOut("Trying to rename dump directory");
                     char tempPath[MAX_PATH_LENGTH] = {0};

--- a/source/main.c
+++ b/source/main.c
@@ -599,6 +599,23 @@ int main()
         }
         fclose (pFile);
 */
+	    getTitleList(mediatype,&titleTitles_available);
+		if (!titleTitle_set){
+			if (tid2 != 0){
+				lsTitle* currentTitle = firstTitle;
+				int i = 0;
+				while(currentTitle != NULL){
+					if (currentTitle->thisTitle == tid2){
+						titleTitle_set = i;
+						getTitleTitle(tid2, mediatype, titleTitle);
+						tid = tid2;
+						break;
+					}
+					currentTitle = currentTitle->nextTitle;
+					i++;
+				}
+			}
+		}
         AM_GetTitleProductCode(mediatype,tid2,productCodeBuffer);
         strncpy(productCode,productCodeBuffer,9);
         secureGameFromProductCode(productCode);
@@ -723,7 +740,7 @@ int main()
     
     consoleSelect(&titleBar);
     textcolour(TEAL);
-    printf("svdt 0.10.42b, meladroit/willidleaway/suloku\n");
+    printf("svdt 0.10.42c, meladroit/willidleaway/suloku\n");
     printf("a hacked-together save data explorer/manager\n");
     gotoxy(CURSOR_WIDTH,2);
     textcolour(GREY);
@@ -756,25 +773,27 @@ int main()
         machine_state = SET_TARGET_TITLE;
     if (machine_state == SET_TARGET_TITLE)
     {
-        getTitleList(mediatype,&titleTitles_available);
+        //getTitleList(mediatype,&titleTitles_available);
         consoleSelect(&statusBar);
         gotoxy(0,10);
         int i;
         for (i=0;i<BOTTOM_WIDTH;i++) { printf(" "); }
-        if (tid2 != 0){
-            lsTitle* currentTitle = firstTitle;
-            int i = 0;
-            while(currentTitle != NULL){
-                if (currentTitle->thisTitle == tid2){
-                    titleTitle_set = i;
-                    getTitleTitle(tid2, mediatype, titleTitle);
-                    tid = tid2;
-                    break;
-                }
-                currentTitle = currentTitle->nextTitle;
-                i++;
-            }
-        }
+		if (!titleTitle_set){
+			if (tid2 != 0){
+				lsTitle* currentTitle = firstTitle;
+				int i = 0;
+				while(currentTitle != NULL){
+					if (currentTitle->thisTitle == tid2){
+						titleTitle_set = i;
+						getTitleTitle(tid2, mediatype, titleTitle);
+						tid = tid2;
+						break;
+					}
+					currentTitle = currentTitle->nextTitle;
+					i++;
+				}
+			}
+		}
         if (!titleTitle_set)
             nthTitleInList(titleTitle_set,mediatype,titleTitle,&tid);
         AM_GetTitleProductCode(mediatype,tid,productCodeBuffer);
@@ -842,12 +861,11 @@ int main()
             }
             if(hidKeysDown() & KEY_A)
             {
-                titleTitle_set = 1;
                 printInstructions();
                 printTarget();
                 previous_state = machine_state;
                 machine_state = SELECT_SDMC;
-                if (canHasConsole == 2)
+                if (canHasConsole == 2 && !titleTitle_set)
                 {
                     debugOut("Trying to rename dump directory");
                     char tempPath[MAX_PATH_LENGTH] = {0};
@@ -866,6 +884,7 @@ int main()
                         printf("Failed with result code %08x",(unsigned int)res);
                     } else { debugOutSuccess("Success!"); }
                 }
+                titleTitle_set = 1;
                 scanDir(&cwd_sdmc,&sdmcArchive,&sdmcFsHandle);
                 clearTitleList();
                 // if we're here, then mediatype!=2, so ...

--- a/source/main.c
+++ b/source/main.c
@@ -577,9 +577,9 @@ int main()
         getTitleTitle(0x0,2,titleTitle);
         titleTitle_set = 1;
     } else {
-		aptOpenSession();
-		APT_GetProgramID(NULL, &tid2);
-		aptCloseSession();
+        aptOpenSession();
+        APT_GetProgramID(NULL, &tid2);
+        aptCloseSession();
 /*
         //Fetch title from /svdt/tid.bin
         FILE * pFile;
@@ -599,23 +599,23 @@ int main()
         }
         fclose (pFile);
 */
-	    getTitleList(mediatype,&titleTitles_available);
-		if (titleTitle_set < 0){
-			if (tid2 != 0){
-				lsTitle* currentTitle = firstTitle;
-				int i = 0;
-				while(currentTitle != NULL){
-					if (currentTitle->thisTitle == tid2){
-						titleTitle_set = i;
-						getTitleTitle(tid2, mediatype, titleTitle);
-						tid = tid2;
-						break;
-					}
-					currentTitle = currentTitle->nextTitle;
-					i++;
-				}
-			}
-		}
+        getTitleList(mediatype,&titleTitles_available);
+        if (titleTitle_set < 0){
+            if (tid2 != 0){
+                lsTitle* currentTitle = firstTitle;
+                int i = 0;
+                while(currentTitle != NULL){
+                    if (currentTitle->thisTitle == tid2){
+                        titleTitle_set = i;
+                        getTitleTitle(tid2, mediatype, titleTitle);
+                        tid = tid2;
+                        break;
+                    }
+                    currentTitle = currentTitle->nextTitle;
+                    i++;
+                }
+            }
+        }
         AM_GetTitleProductCode(mediatype,tid2,productCodeBuffer);
         strncpy(productCode,productCodeBuffer,9);
         secureGameFromProductCode(productCode);
@@ -778,22 +778,22 @@ int main()
         gotoxy(0,10);
         int i;
         for (i=0;i<BOTTOM_WIDTH;i++) { printf(" "); }
-		if (titleTitle_set < 0){
-			if (tid2 != 0){
-				lsTitle* currentTitle = firstTitle;
-				int i = 0;
-				while(currentTitle != NULL){
-					if (currentTitle->thisTitle == tid2){
-						titleTitle_set = i;
-						getTitleTitle(tid2, mediatype, titleTitle);
-						tid = tid2;
-						break;
-					}
-					currentTitle = currentTitle->nextTitle;
-					i++;
-				}
-			}
-		}
+        if (titleTitle_set < 0){
+            if (tid2 != 0){
+                lsTitle* currentTitle = firstTitle;
+                int i = 0;
+                while(currentTitle != NULL){
+                    if (currentTitle->thisTitle == tid2){
+                        titleTitle_set = i;
+                        getTitleTitle(tid2, mediatype, titleTitle);
+                        tid = tid2;
+                        break;
+                    }
+                    currentTitle = currentTitle->nextTitle;
+                    i++;
+                }
+            }
+        }
         if (titleTitle_set < 0)
             nthTitleInList(titleTitle_set,mediatype,titleTitle,&tid);
         AM_GetTitleProductCode(mediatype,tid,productCodeBuffer);
@@ -817,6 +817,7 @@ int main()
             
     int heldU = 0;
     int heldD = 0;
+    bool firstloop = false;
     while (aptMainLoop())
     {
         hidScanInput();
@@ -859,7 +860,7 @@ int main()
                 printf(productCode);
                 printf(" - %016llX", tid);
             }
-            if(hidKeysDown() & KEY_A || titleTitle_set > -1)
+            if(hidKeysDown() & KEY_A || (titleTitle_set > -1 && !firstloop))
             {
                 printInstructions();
                 printTarget();
@@ -921,6 +922,7 @@ int main()
             // Flush and swap framebuffers
             gfxFlushBuffers();
             gfxSwapBuffers();
+            firstloop = true;
             continue;
         }
         if(machine_state == CONFIRM_SECURE_VALUE)
@@ -1253,10 +1255,10 @@ int main()
                         gotoParentDirectory(ccwd);
                         debugOut("Navigating to parent directory.");
                         cwd_needs_update = 1;
-					    break;
+                        break;
                     }
-					if (ccwd->lsOffset == 0)
-						break;
+                    if (ccwd->lsOffset == 0)
+                        break;
                 default: ;
                     lsLine* selection = ccwd->firstLine;
                     int i;

--- a/source/mh4u.c
+++ b/source/mh4u.c
@@ -42,7 +42,7 @@ int MH4U_decryptBuff(u8** inbuff, u64 lSize){
     buffer = *inbuff;
 
     //Start decryption
-        printf ("Decrypting...\n");
+        //printf ("Decrypting...\n");
 
         BLOWFISH_CTX ctx;
         Blowfish_Init (&ctx, (unsigned char*)"blowfish key iorajegqmrna4itjeangmb agmwgtobjteowhv9mope", 56);
@@ -52,12 +52,15 @@ int MH4U_decryptBuff(u8** inbuff, u64 lSize){
         //Verify
         unsigned short SIXTEEN;
         memcpy (&SIXTEEN, buffer, 2);
-        if (SIXTEEN != 16) printf ("\tDecryption failed!\n");
+        if (SIXTEEN != 16){
+			//printf ("\tDecryption failed!\n");
+			return 0;
+		}
 
         //Get Key
         unsigned short KEY;
         memcpy (&KEY, buffer+2, 2);
-        printf("\tKey: %X\n",KEY);
+        //printf("\tKey: %X\n",KEY);
         unsigned short out;
         unsigned int tempkey = KEY;
         unsigned int csum1 = 0;
@@ -90,15 +93,15 @@ int MH4U_decryptBuff(u8** inbuff, u64 lSize){
             csum_calc += byte;
         }
         csum_calc &= 0xFFFFFFFF;
-        printf ("\tCalculated checksum: %08X\n", csum_calc);
+        //printf ("\tCalculated checksum: %08X\n", csum_calc);
 
         //Get file checksum
         unsigned int csum;
         csum = ((csum2 & 0xFFFF) << 16) | (csum1 & 0xFFFF);
-        printf ("\tFile checksum:       %08X\n", csum);
+        //printf ("\tFile checksum:       %08X\n", csum);
 
         if (csum != csum_calc){
-            printf("Checksum mismatch!\n");
+            //printf("Checksum mismatch!\n");
             return 0;
         }
 
@@ -112,7 +115,7 @@ int MH4U_encryptBuff(u8** inbuff, u64 lSize){
 
     buffer2 = *inbuff;
 
-        printf("Encrypting buffer...\n");
+        //printf("Encrypting buffer...\n");
     //put 16 bit "16" magic in buffer2
         short tmp = 16;
         memcpy (buffer2, &tmp, 2);
@@ -125,7 +128,7 @@ int MH4U_encryptBuff(u8** inbuff, u64 lSize){
             csum_calc2 += byte2;
         }
         csum_calc2 &= 0xFFFFFFFF;
-        printf ("\tCalculated checksum: %08X\n", csum_calc2);
+        //printf ("\tCalculated checksum: %08X\n", csum_calc2);
 
         //put checksum in buffer2
         memcpy (buffer2+4, &csum_calc2, 4);
@@ -137,7 +140,7 @@ int MH4U_encryptBuff(u8** inbuff, u64 lSize){
         KEY2 = ((KEY2 << 7) & 0xFFFF) | (KEY2 >> 9); //16bit rotated left 7x
         //printf("\tkey2: %d\n", KEY2);
         KEY2 ^= 0x484D; // xor with "MH"
-        printf("\tKEY: %X\n", KEY2);
+        //printf("\tKEY: %X\n", KEY2);
 
         //put 16 bit key in buffer2
         tmp = KEY2;

--- a/source/secure_values.c
+++ b/source/secure_values.c
@@ -22,7 +22,7 @@ const char const secureProductCodes[PRECONF_GAMES][16] = {"CTR-P-EGD",
     "CTR-P-EKJ", "CTR-P-EK2",
     "CTR-P-ECR", "CTR-P-ECL"}; // minus region
 const char* const pokeRumbleWorldCode = "CTR-N-KCF";
-const char* const MH4UCode = "CTR-P-BFG";
+const char* const MH4UCode = "XXX-X-XXX"; //Monster Hunter 4 Ultimate product code = "CTR-P-BFG", disabled until we know for sure it uses secure value.
 
 char configProductCode[9] = {0};
 
@@ -617,7 +617,8 @@ Result getMH4USecureValue()
 	}
 	if (res != 0 ) return res;
 
-	MH4U_decryptBuff(&buffer, size);
+	if (!MH4U_decryptBuff(&buffer, size))
+		return 1;
         
     memcpy((void*)secureValue,(void*)(buffer+8+0x112),8);
     secureValueSet = 1;


### PR DESCRIPTION
- Use title fetching for emergency mode too.
- Disabled printf in mh4u decryption code (it is called before the console is initiated and it messes it up).
- Disabled MH4U secure value patching until we know if it really uses secure value or not (via impossible product code)

Two users have now said that they could restore old savegames from MH4U with no problem, so I think until somebody complains about ASR for that game it's better to assume it doesn't use it.
