### PR TITLE
Fix emergency mode and a couple more things

### DIFF
--- a/source/svdt.c
+++ b/source/svdt.c
@@ -42,7 +42,9 @@ void gotoSubDirectory(lsDir* dir, char* basename)
     cwd = strcat(cwd,basename);
     if (cwd[strlen(cwd+1)] != '/')
     {
-        //printf("\nappending slash");
+		if(canHasConsole){
+			//printf("\nappending slash");
+		}
         cwd = strcat(cwd,"/");
     }
     if (canHasConsole)
@@ -233,6 +235,7 @@ Result getTitleTitle(u64 tid, u8 mediatype, char* titleTitle)
     {
         titleTitle[forbiddenChar-titleTitle] = ' ';
     }
+	if (titleTitle[strlen(titleTitle)-1] == ' ') titleTitle[strlen(titleTitle)-1] = '\0';
     return ret;
 }
 


### PR DESCRIPTION
I thought about changing KEY_DRIGHT and KEY_DLEFT or L/R to be used as ZL and ZR.

I personally use RIGHT/LEFT to change from savedata to SDcard, but maybe other people use L/R so I just added it to new3DS controls. Feel free to leave it as is or put fast scrolling on whatever button.

Problem with emergency mode and smash bros was folder name being "Super Smash Bros ", that last space was breaking it. It should have worked fine with 0.2 though, but I don't feel like checkin since its working fine on o3DS in my commit.
